### PR TITLE
Update command.go

### DIFF
--- a/command.go
+++ b/command.go
@@ -87,8 +87,9 @@ func (c *Command) RunInDirTimeoutPipeline(timeout time.Duration, dir string, std
 				return fmt.Errorf("fail to kill process: %v", err)
 			}
 		}
-
-		<-done
+		go func() {
+			<-done
+		}
 		return ErrExecTimeout{timeout}
 	case err = <-done:
 	}


### PR DESCRIPTION
fix RunInDirTimeoutPipeline can't quit in some cases. example : "ping 127.0.0.1"