### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/command.go
+++ b/command.go
@@ -117,7 +117,7 @@ func (c *Command) RunInDirPipeline(dir string, stdout, stderr io.Writer) error {
 	return c.RunInDirTimeoutPipeline(-1, dir, stdout, stderr)
 }
 
-// RunInDir executes the command in given directory
+// RunInDirBytes executes the command in given directory
 // and returns stdout in []byte and error (combined with stderr).
 func (c *Command) RunInDirBytes(dir string) ([]byte, error) {
 	return c.RunInDirTimeout(-1, dir)

--- a/commit.go
+++ b/commit.go
@@ -97,7 +97,7 @@ func (c *Commit) GetCommitByPath(relpath string) (*Commit, error) {
 	return c.repo.getCommitByPathWithID(c.ID, relpath)
 }
 
-// AddAllChanges marks local changes to be ready for commit.
+// AddChanges marks local changes to be ready for commit.
 func AddChanges(repoPath string, all bool, files ...string) error {
 	cmd := NewCommand("add")
 	if all {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?