### PR TITLE
tree_blob: return blob contents for blob and exec (#56)

### DIFF
--- a/tree_blob.go
+++ b/tree_blob.go
@@ -53,7 +53,7 @@ func (t *Tree) Blob(subpath string, opts ...LsTreeOptions) (*Blob, error) {
 		return nil, err
 	}
 
-	if e.IsBlob() {
+	if e.IsBlob() || e.IsExec() {
 		return e.Blob(), nil
 	}
 


### PR DESCRIPTION
This PR adds an `or` conditional to return blob content if a file is an
executable (entry mode 0100755). Prior to this `Blob` func only returned
file contents if a file was of type blob (entry mode 010644). This in a
resulted error to be returned for certain files that were for instance
bash scripts which had the executable mode bit set.