### PR TITLE
Fix bad parsing for some .gitmodules that path and url not ordered

### DIFF
--- a/commit_submodule.go
+++ b/commit_submodule.go
@@ -42,9 +42,12 @@ func (c *Commit) Submodules() (Submodules, error) {
 		c.submodules = newObjectCache()
 		var inSection bool
 		var path string
+		var url string
 		for scanner.Scan() {
 			if strings.HasPrefix(scanner.Text(), "[submodule") {
 				inSection = true
+				path = ""
+				url = ""
 				continue
 			} else if !inSection {
 				continue
@@ -55,9 +58,13 @@ func (c *Commit) Submodules() (Submodules, error) {
 			case "path":
 				path = strings.TrimSpace(fields[1])
 			case "url":
+				url = strings.TrimSpace(fields[1])
+			}
+
+			if len(path) > 0 && len(url) > 0 {
 				mod := &Submodule{
 					Name: path,
-					URL:  strings.TrimSpace(fields[1]),
+					URL: url,
 				}
 
 				mod.Commit, c.submodulesErr = c.repo.RevParse(c.id.String() + ":" + mod.Name)


### PR DESCRIPTION
for example, the .gitmodules in https://git.zx2c4.com/cgit is like this:

```.gitmodules
[submodule "git"]
	url = https://git.kernel.org/pub/scm/git/git.git
	path = git
```