### PR TITLE
fix: typo in struct AddOptions

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -388,7 +388,7 @@ type AddOptions struct {
 	// Indicates whether to add all changes to index.
 	All bool
 	// The specific pathspecs to be added to index.
-	Pathsepcs []string
+	Pathspecs []string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
 	Timeout time.Duration
@@ -407,9 +407,9 @@ func Add(repoPath string, opts ...AddOptions) error {
 	if opt.All {
 		cmd.AddArgs("--all")
 	}
-	if len(opt.Pathsepcs) > 0 {
+	if len(opt.Pathspecs) > 0 {
 		cmd.AddArgs("--")
-		cmd.AddArgs(opt.Pathsepcs...)
+		cmd.AddArgs(opt.Pathspecs...)
 	}
 	_, err := cmd.RunInDirWithTimeout(opt.Timeout, repoPath)
 	return err

--- a/repo_test.go
+++ b/repo_test.go
@@ -328,7 +328,7 @@ func TestRepository_Add(t *testing.T) {
 	// Make sure it does not blow up
 	if err := r.Add(AddOptions{
 		All:       true,
-		Pathsepcs: []string{"TESTFILE"},
+		Pathspecs: []string{"TESTFILE"},
 	}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #65

### Describe the pull request

This fixes a typo in `AddOptions`.

Given this changes the public API, an alternative would be to deprecate `Pathsepcs`, add `Pathspecs`, and add a small shim. I'm happy to do that if y'all would rather :)

Link to the issue: #65 

### Checklist

- [X] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [X] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [X] I have added test cases to cover the new code.
