### PR TITLE
fix: be tolerant to implicit submodules

### DIFF
--- a/tree_entry.go
+++ b/tree_entry.go
@@ -243,10 +243,10 @@ func (es Entries) CommitsInfo(commit *Commit, opts ...CommitsInfoOptions) ([]*En
 
 				// Get extra information for submodules
 				if e.IsCommit() {
+					// Be tolerant to implicit submodules
 					info.Submodule, err = commit.Submodule(epath)
 					if err != nil {
-						setError(fmt.Errorf("get submodule %q: %v", epath, err))
-						return
+						info.Submodule = &Submodule{Name: epath}
 					}
 				}
 


### PR DESCRIPTION
### Describe the pull request

Git itself allows adding another Git repository inside the current repository without properly defining as a submodule, so we need to be tolerant about that.

Link to the issue: https://github.com/gogs/gogs/issues/6436

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code.
