### PR TITLE
feat: run command with context

### DIFF
--- a/command.go
+++ b/command.go
@@ -17,10 +17,11 @@ import (
 
 // Command contains the name, arguments and environment variables of a command.
 type Command struct {
-	name string
-	args []string
-	envs []string
-	ctx  context.Context
+	name    string
+	args    []string
+	envs    []string
+	timeout time.Duration
+	ctx     context.Context
 }
 
 // CommandOptions contains options for running a command.
@@ -69,17 +70,29 @@ func (c *Command) AddEnvs(envs ...string) *Command {
 	return c
 }
 
-// WithContext sets the context for the command.
-func (c *Command) WithContext(ctx context.Context) *Command {
+// WithContext returns a new Command with the given context.
+func (c Command) WithContext(ctx context.Context) *Command {
 	c.ctx = ctx
-	return c
+	return &c
+}
+
+// WithTimeout returns a new Command with given timeout.
+func (c Command) WithTimeout(timeout time.Duration) *Command {
+	c.timeout = timeout
+	return &c
+}
+
+// SetTimeout sets the timeout for the command.
+func (c *Command) SetTimeout(timeout time.Duration) {
+	c.timeout = timeout
 }
 
 // AddOptions adds options to the command.
 // Note: only the last option will take effect if there are duplicated options.
 func (c *Command) AddOptions(opts ...CommandOptions) *Command {
 	for _, opt := range opts {
-		c = c.WithContext(opt.Context)
+		c.timeout = opt.Timeout
+		c.ctx = opt.Context
 		c.AddArgs(opt.Args...)
 		c.AddEnvs(opt.Envs...)
 	}
@@ -132,6 +145,8 @@ type RunInDirOptions struct {
 	// Stderr is the error output from the command.
 	Stderr io.Writer
 	// Timeout is the duration to wait before timing out.
+	//
+	// Deprecated: Use CommandOptions.Timeout or *Command.WithTimeout instead.
 	Timeout time.Duration
 }
 
@@ -145,10 +160,15 @@ func (c *Command) RunInDirWithOptions(dir string, opts ...RunInDirOptions) (err 
 	if len(opts) > 0 {
 		opt = opts[0]
 	}
-	if opt.Timeout < 0 {
-		opt.Timeout = -1
-	} else if opt.Timeout == 0 {
-		opt.Timeout = DefaultTimeout
+
+	timeout := c.timeout
+	// TODO: remove this in newer version
+	if opt.Timeout > 0 {
+		timeout = opt.Timeout
+	}
+
+	if timeout == 0 {
+		timeout = DefaultTimeout
 	}
 
 	buf := new(bytes.Buffer)
@@ -164,9 +184,9 @@ func (c *Command) RunInDirWithOptions(dir string, opts ...RunInDirOptions) (err 
 
 	defer func() {
 		if len(dir) == 0 {
-			log("[timeout: %v] %s\n%s", opt.Timeout, c, buf.Bytes())
+			log("[timeout: %v] %s\n%s", timeout, c, buf.Bytes())
 		} else {
-			log("[timeout: %v] %s: %s\n%s", opt.Timeout, dir, c, buf.Bytes())
+			log("[timeout: %v] %s: %s\n%s", timeout, dir, c, buf.Bytes())
 		}
 	}()
 
@@ -175,9 +195,9 @@ func (c *Command) RunInDirWithOptions(dir string, opts ...RunInDirOptions) (err 
 		ctx = c.ctx
 	}
 
-	if opt.Timeout > 0 {
+	if timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, opt.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer func() {
 			cancel()
 			if err == context.DeadlineExceeded {
@@ -219,55 +239,72 @@ func (c *Command) RunInDirWithOptions(dir string, opts ...RunInDirOptions) (err 
 
 }
 
+// RunInDirPipeline executes the command in given directory and default timeout
+// duration. It pipes stdout and stderr to supplied io.Writer.
+func (c *Command) RunInDirPipeline(stdout, stderr io.Writer, dir string) error {
+	return c.RunInDirWithOptions(dir, RunInDirOptions{
+		Stdin:  nil,
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+}
+
 // RunInDirPipelineWithTimeout executes the command in given directory and
 // timeout duration. It pipes stdout and stderr to supplied io.Writer.
 // DefaultTimeout will be used if the timeout duration is less than
 // time.Nanosecond (i.e. less than or equal to 0). It returns an ErrExecTimeout
 // if the execution was timed out.
+//
+// Deprecated: Use RunInDirPipeline and CommandOptions instead.
+// TODO: remove this in the next major version
 func (c *Command) RunInDirPipelineWithTimeout(timeout time.Duration, stdout, stderr io.Writer, dir string) (err error) {
-	return c.RunInDirWithOptions(dir, RunInDirOptions{
-		Stdin:   nil,
-		Stdout:  stdout,
-		Stderr:  stderr,
-		Timeout: timeout,
-	})
-}
-
-// RunInDirPipeline executes the command in given directory and default timeout
-// duration. It pipes stdout and stderr to supplied io.Writer.
-func (c *Command) RunInDirPipeline(stdout, stderr io.Writer, dir string) error {
-	return c.RunInDirPipelineWithTimeout(DefaultTimeout, stdout, stderr, dir)
+	if timeout != 0 {
+		c = c.WithTimeout(timeout)
+	}
+	return c.RunInDirPipeline(stdout, stderr, dir)
 }
 
 // RunInDirWithTimeout executes the command in given directory and timeout
 // duration. It returns stdout in []byte and error (combined with stderr).
+//
+// Deprecated: Use RunInDir and CommandOptions instead.
+// TODO: remove this in the next major version
 func (c *Command) RunInDirWithTimeout(timeout time.Duration, dir string) ([]byte, error) {
-	stdout := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
-	if err := c.RunInDirPipelineWithTimeout(timeout, stdout, stderr, dir); err != nil {
-		return nil, concatenateError(err, stderr.String())
+	if timeout != 0 {
+		c = c.WithTimeout(timeout)
 	}
-	return stdout.Bytes(), nil
+	return c.RunInDir(dir)
 }
 
 // RunInDir executes the command in given directory and default timeout
 // duration. It returns stdout and error (combined with stderr).
 func (c *Command) RunInDir(dir string) ([]byte, error) {
-	return c.RunInDirWithTimeout(DefaultTimeout, dir)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	if err := c.RunInDirPipeline(stdout, stderr, dir); err != nil {
+		return nil, concatenateError(err, stderr.String())
+	}
+	return stdout.Bytes(), nil
 }
 
 // RunWithTimeout executes the command in working directory and given timeout
 // duration. It returns stdout in string and error (combined with stderr).
+//
+// Deprecated: Use RunInDir and CommandOptions instead.
+// TODO: remove this in the next major version
 func (c *Command) RunWithTimeout(timeout time.Duration) ([]byte, error) {
-	stdout, err := c.RunInDirWithTimeout(timeout, "")
-	if err != nil {
-		return nil, err
+	if timeout != 0 {
+		c = c.WithTimeout(timeout)
 	}
-	return stdout, nil
+	return c.Run()
 }
 
 // Run executes the command in working directory and default timeout duration.
 // It returns stdout in string and error (combined with stderr).
 func (c *Command) Run() ([]byte, error) {
-	return c.RunWithTimeout(DefaultTimeout)
+	stdout, err := c.RunInDir("")
+	if err != nil {
+		return nil, err
+	}
+	return stdout, nil
 }

--- a/command_test.go
+++ b/command_test.go
@@ -60,6 +60,6 @@ func TestCommand_AddEnvs(t *testing.T) {
 }
 
 func TestCommand_RunWithTimeout(t *testing.T) {
-	_, err := NewCommand("version").RunWithTimeout(time.Nanosecond)
+	_, err := NewCommand("version").WithTimeout(time.Nanosecond).Run()
 	assert.Equal(t, ErrExecTimeout, err)
 }

--- a/repo.go
+++ b/repo.go
@@ -60,6 +60,8 @@ type InitOptions struct {
 	Bare bool
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -119,6 +121,8 @@ type CloneOptions struct {
 	Depth uint64
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -165,6 +169,8 @@ type FetchOptions struct {
 	Prune bool
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -200,6 +206,8 @@ type PullOptions struct {
 	Branch string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -236,6 +244,8 @@ func (r *Repository) Pull(opts ...PullOptions) error {
 type PushOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -272,6 +282,8 @@ type CheckoutOptions struct {
 	BaseBranch string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -315,6 +327,8 @@ type ResetOptions struct {
 	Hard bool
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -353,6 +367,8 @@ func (r *Repository) Reset(rev string, opts ...ResetOptions) error {
 type MoveOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -391,6 +407,8 @@ type AddOptions struct {
 	Pathspecs []string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -433,6 +451,8 @@ type CommitOptions struct {
 	Author *Signature
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -488,6 +508,8 @@ type NameStatus struct {
 type ShowNameStatusOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -554,6 +576,8 @@ func (r *Repository) ShowNameStatus(rev string, opts ...ShowNameStatusOptions) (
 type RevParseOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -598,6 +622,8 @@ type CountObject struct {
 type CountObjectsOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -663,6 +689,8 @@ func (r *Repository) CountObjects(opts ...CountObjectsOptions) (*CountObject, er
 type FsckOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions

--- a/repo_blame.go
+++ b/repo_blame.go
@@ -14,6 +14,8 @@ import (
 type BlameOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions

--- a/repo_blob.go
+++ b/repo_blob.go
@@ -12,6 +12,8 @@ import "time"
 type CatFileBlobOptions struct {
 	// The timeout duration before giving up for each shell command execution.
 	// The default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -72,6 +72,8 @@ loop:
 type CatFileCommitOptions struct {
 	// The timeout duration before giving up for each shell command execution.
 	// The default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions

--- a/repo_diff.go
+++ b/repo_diff.go
@@ -20,6 +20,8 @@ type DiffOptions struct {
 	Base string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions

--- a/repo_grep.go
+++ b/repo_grep.go
@@ -27,6 +27,8 @@ type GrepOptions struct {
 	ExtendedRegexp bool
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions

--- a/repo_pull.go
+++ b/repo_pull.go
@@ -15,6 +15,8 @@ import (
 type MergeBaseOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions

--- a/repo_reference.go
+++ b/repo_reference.go
@@ -39,7 +39,11 @@ type Reference struct {
 type ShowRefVerifyOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
+	// The additional options to be passed to the underlying git.
+	CommandOptions
 }
 
 var ErrReferenceNotExist = errors.New("reference does not exist")
@@ -52,7 +56,8 @@ func ShowRefVerify(repoPath, ref string, opts ...ShowRefVerifyOptions) (string, 
 		opt = opts[0]
 	}
 
-	stdout, err := NewCommand("show-ref", "--verify", ref).RunInDirWithTimeout(opt.Timeout, repoPath)
+	cmd := NewCommand("show-ref", "--verify", ref).AddOptions(opt.CommandOptions)
+	stdout, err := cmd.RunInDirWithTimeout(opt.Timeout, repoPath)
 	if err != nil {
 		if strings.Contains(err.Error(), "not a valid ref") {
 			return "", ErrReferenceNotExist
@@ -137,7 +142,11 @@ type SymbolicRefOptions struct {
 	Ref string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
+	// The additional options to be passed to the underlying git.
+	CommandOptions
 }
 
 // SymbolicRef returns the reference name (e.g. "refs/heads/master") pointed by
@@ -149,7 +158,7 @@ func SymbolicRef(repoPath string, opts ...SymbolicRefOptions) (string, error) {
 		opt = opts[0]
 	}
 
-	cmd := NewCommand("symbolic-ref")
+	cmd := NewCommand("symbolic-ref").AddOptions(opt.CommandOptions)
 	if opt.Name == "" {
 		opt.Name = "HEAD"
 	}
@@ -184,6 +193,8 @@ type ShowRefOptions struct {
 	Patterns []string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -250,7 +261,11 @@ type DeleteBranchOptions struct {
 	Force bool
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
+	// The additional options to be passed to the underlying git.
+	CommandOptions
 }
 
 // DeleteBranch deletes the branch from the repository in given path.
@@ -260,7 +275,7 @@ func DeleteBranch(repoPath, name string, opts ...DeleteBranchOptions) error {
 		opt = opts[0]
 	}
 
-	cmd := NewCommand("branch")
+	cmd := NewCommand("branch").AddOptions(opt.CommandOptions)
 	if opt.Force {
 		cmd.AddArgs("-D")
 	} else {

--- a/repo_remote.go
+++ b/repo_remote.go
@@ -25,6 +25,8 @@ type LsRemoteOptions struct {
 	Patterns []string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -94,6 +96,8 @@ type RemoteAddOptions struct {
 	MirrorFetch bool
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -143,6 +147,8 @@ func (r *Repository) AddRemote(name, url string, opts ...RemoteAddOptions) error
 type RemoteRemoveOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -194,6 +200,8 @@ func (r *Repository) RemoveRemote(name string, opts ...RemoteRemoveOptions) erro
 type RemotesOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -233,6 +241,8 @@ type RemoteGetURLOptions struct {
 	All bool
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -276,6 +286,8 @@ type RemoteSetURLOptions struct {
 	Regex string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -327,6 +339,8 @@ type RemoteSetURLAddOptions struct {
 	Push bool
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -371,6 +385,8 @@ type RemoteSetURLDeleteOptions struct {
 	Push bool
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions

--- a/repo_tag.go
+++ b/repo_tag.go
@@ -104,6 +104,8 @@ func (r *Repository) getTag(timeout time.Duration, id *SHA1) (*Tag, error) {
 type TagOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -152,6 +154,8 @@ type TagsOptions struct {
 	Pattern string
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -222,6 +226,8 @@ type CreateTagOptions struct {
 	Author *Signature
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions
@@ -257,7 +263,11 @@ func (r *Repository) CreateTag(name, rev string, opts ...CreateTagOptions) error
 type DeleteTagOptions struct {
 	// The timeout duration before giving up for each shell command execution.
 	// The default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
+	// The additional options to be passed to the underlying git.
+	CommandOptions
 }
 
 // DeleteTag deletes a tag from the repository.
@@ -267,6 +277,8 @@ func (r *Repository) DeleteTag(name string, opts ...DeleteTagOptions) error {
 		opt = opts[0]
 	}
 
-	_, err := NewCommand("tag", "--delete", name).RunInDirWithTimeout(opt.Timeout, r.path)
+	_, err := NewCommand("tag", "--delete", name).
+		AddOptions(opt.CommandOptions).
+		RunInDirWithTimeout(opt.Timeout, r.path)
 	return err
 }

--- a/repo_tree.go
+++ b/repo_tree.go
@@ -91,6 +91,8 @@ func parseTree(t *Tree, data []byte) ([]*TreeEntry, error) {
 type LsTreeOptions struct {
 	// The timeout duration before giving up for each shell command execution. The
 	// default timeout duration will be used when not supplied.
+	//
+	// Deprecated: Use CommandOptions.Timeout instead.
 	Timeout time.Duration
 	// The additional options to be passed to the underlying git.
 	CommandOptions


### PR DESCRIPTION
Pass a context down to *exec.Command and make timing out optional when o.Timeout < 0.

Using `context.Background()` _all the time_ is not practical as sometimes we need to stop the execution when _a_ parent context stops.

### Describe the pull request

A clear and concise description of what the pull request is about, i.e. what problem should be fixed?

Link to the issue: <!-- paste the issue link here, or put "n/a" if not applicable -->

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code.
