### PR TITLE
fix: wiki delete issue

### DIFF
--- a/repo_tree_test.go
+++ b/repo_tree_test.go
@@ -11,17 +11,36 @@ import (
 )
 
 func TestRepository_LsTree(t *testing.T) {
-	// Make sure it does not blow up
-	tree, err := testrepo.LsTree("master", LsTreeOptions{})
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		options LsTreeOptions
+	}{
+		{
+			options: LsTreeOptions{},
+		},
+		{
+			options: LsTreeOptions{
+				CommandOptions: CommandOptions{
+					Args: []string{"-z"},
+				},
+			},
+		},
 	}
-	assert.NotNil(t, tree)
 
-	// Tree ID for "gogs/" directory
-	tree, err = testrepo.LsTree("fcf7087e732bfe3c25328248a9bf8c3ccd85bed4", LsTreeOptions{})
-	if err != nil {
-		t.Fatal(err)
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			// Make sure it does not blow up
+			tree, err := testrepo.LsTree("master", test.options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.NotNil(t, tree)
+
+			// Tree ID for "gogs/" directory
+			tree, err = testrepo.LsTree("fcf7087e732bfe3c25328248a9bf8c3ccd85bed4", test.options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.NotNil(t, tree)
+		})
 	}
-	assert.NotNil(t, tree)
 }


### PR DESCRIPTION
Fixes [#7596](https://github.com/gogs/gogs/issues/7596)

### Describe the pull request

It seems there's an issue with the handling of special characters in wiki names, where Git internally escapes them. This creates a mismatch between the escaped filenames and the actual filenames, making it challenging to delete files accurately. As a result, the deletion process is not functioning as expected.

According to the [Git documentation](https://git-scm.com/docs/git-ls-tree#Documentation/git-ls-tree.txt--z), when the `-z` option is used, filenames are not quoted, and the output is terminated with a null character (`\0`). For more clarification, refer to the documentation on [core.quotePath](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath) as well.

This pull request addresses the issue by incorporating a conditional check for the `-z` option during the git `ls-tree` operation. It also updates the line terminator in the `parseTree` function accordingly.

This particular modification is not sufficient to fully resolve the issue. Another pull request will be submitted in the [gogs/gogs](https://github.com/gogs/gogs) repository to address the remaining aspects of the problem.

https://github.com/gogs/git-module/assets/25850690/d6c0ea9f-0d5f-4ca0-b31b-ad869f348974

Link to the issue: [#7596](https://github.com/gogs/gogs/issues/7596)

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code.
