### PR TITLE
sec: added --end-of-options to prevent unintended options

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -83,6 +83,7 @@ func Init(path string, opts ...InitOptions) error {
 	if opt.Bare {
 		cmd.AddArgs("--bare")
 	}
+	cmd.AddArgs("--end-of-options")
 	_, err = cmd.RunInDirWithTimeout(opt.Timeout, path)
 	return err
 }
@@ -157,6 +158,7 @@ func Clone(url, dst string, opts ...CloneOptions) error {
 		cmd.AddArgs("--depth", strconv.FormatUint(opt.Depth, 10))
 	}
 
+	cmd.AddArgs("--end-of-options")
 	_, err = cmd.AddArgs(url, dst).RunWithTimeout(opt.Timeout)
 	return err
 }
@@ -259,7 +261,7 @@ func Push(repoPath, remote, branch string, opts ...PushOptions) error {
 		opt = opts[0]
 	}
 
-	cmd := NewCommand("push").AddOptions(opt.CommandOptions).AddArgs(remote, branch)
+	cmd := NewCommand("push").AddOptions(opt.CommandOptions).AddArgs("--end-of-options", remote, branch)
 	_, err := cmd.RunInDirWithTimeout(opt.Timeout, repoPath)
 	return err
 }
@@ -346,7 +348,7 @@ func Reset(repoPath, rev string, opts ...ResetOptions) error {
 		cmd.AddArgs("--hard")
 	}
 
-	_, err := cmd.AddOptions(opt.CommandOptions).AddArgs(rev).RunInDir(repoPath)
+	_, err := cmd.AddOptions(opt.CommandOptions).AddArgs("--end-of-options", rev).RunInDir(repoPath)
 	return err
 }
 
@@ -382,7 +384,7 @@ func Move(repoPath, src, dst string, opts ...MoveOptions) error {
 		opt = opts[0]
 	}
 
-	_, err := NewCommand("mv").AddOptions(opt.CommandOptions).AddArgs(src, dst).RunInDirWithTimeout(opt.Timeout, repoPath)
+	_, err := NewCommand("mv").AddOptions(opt.CommandOptions).AddArgs("--end-of-options", src, dst).RunInDirWithTimeout(opt.Timeout, repoPath)
 	return err
 }
 
@@ -549,7 +551,7 @@ func ShowNameStatus(repoPath, rev string, opts ...ShowNameStatusOptions) (*NameS
 	stderr := new(bytes.Buffer)
 	cmd := NewCommand("show", "--name-status", "--pretty=format:''").
 		AddOptions(opt.CommandOptions).
-		AddArgs(rev)
+		AddArgs("--end-of-options", rev)
 	err := cmd.RunInDirPipelineWithTimeout(opt.Timeout, w, stderr, repoPath)
 	_ = w.Close() // Close writer to exit parsing goroutine
 	if err != nil {

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -221,7 +221,7 @@ func (r *Repository) Log(rev string, opts ...LogOptions) ([]*Commit, error) {
 
 	cmd := NewCommand("log").
 		AddOptions(opt.CommandOptions).
-		AddArgs("--pretty="+LogFormatHashOnly, rev)
+		AddArgs("--pretty=" + LogFormatHashOnly)
 	if opt.MaxCount > 0 {
 		cmd.AddArgs("--max-count=" + strconv.Itoa(opt.MaxCount))
 	}
@@ -237,6 +237,7 @@ func (r *Repository) Log(rev string, opts ...LogOptions) ([]*Commit, error) {
 	if opt.RegexpIgnoreCase {
 		cmd.AddArgs("--regexp-ignore-case")
 	}
+	cmd.AddArgs("--end-of-options", rev)
 	cmd.AddArgs("--")
 	if opt.Path != "" {
 		cmd.AddArgs(escapePath(opt.Path))
@@ -406,6 +407,7 @@ func DiffNameOnly(repoPath, base, head string, opts ...DiffNameOnlyOptions) ([]s
 	cmd := NewCommand("diff").
 		AddOptions(opt.CommandOptions).
 		AddArgs("--name-only")
+	cmd.AddArgs("--end-of-options")
 	if opt.NeedsMergeBase {
 		cmd.AddArgs(base + "..." + head)
 	} else {
@@ -471,7 +473,8 @@ func (r *Repository) RevListCount(refspecs []string, opts ...RevListCountOptions
 
 	cmd := NewCommand("rev-list").
 		AddOptions(opt.CommandOptions).
-		AddArgs("--count")
+		AddArgs("--count").
+		AddArgs("--end-of-options")
 	cmd.AddArgs(refspecs...)
 	cmd.AddArgs("--")
 	if opt.Path != "" {
@@ -512,6 +515,7 @@ func (r *Repository) RevList(refspecs []string, opts ...RevListOptions) ([]*Comm
 	}
 
 	cmd := NewCommand("rev-list").AddOptions(opt.CommandOptions)
+	cmd.AddArgs("--end-of-options")
 	cmd.AddArgs(refspecs...)
 	cmd.AddArgs("--")
 	if opt.Path != "" {

--- a/repo_diff.go
+++ b/repo_diff.go
@@ -45,7 +45,7 @@ func (r *Repository) Diff(rev string, maxFiles, maxFileLines, maxLineChars int, 
 		if commit.ParentsCount() == 0 {
 			cmd = cmd.AddArgs("show").
 				AddOptions(opt.CommandOptions).
-				AddArgs("--full-index", rev)
+				AddArgs("--full-index", "--end-of-options", rev)
 		} else {
 			c, err := commit.Parent(0)
 			if err != nil {
@@ -53,12 +53,12 @@ func (r *Repository) Diff(rev string, maxFiles, maxFileLines, maxLineChars int, 
 			}
 			cmd = cmd.AddArgs("diff").
 				AddOptions(opt.CommandOptions).
-				AddArgs("--full-index", "-M", c.ID.String(), rev)
+				AddArgs("--full-index", "-M", c.ID.String(), "--end-of-options", rev)
 		}
 	} else {
 		cmd = cmd.AddArgs("diff").
 			AddOptions(opt.CommandOptions).
-			AddArgs("--full-index", "-M", opt.Base, rev)
+			AddArgs("--full-index", "-M", opt.Base, "--end-of-options", rev)
 	}
 
 	stdout, w := io.Pipe()
@@ -114,7 +114,7 @@ func (r *Repository) RawDiff(rev string, diffType RawDiffFormat, w io.Writer, op
 		if commit.ParentsCount() == 0 {
 			cmd = cmd.AddArgs("show").
 				AddOptions(opt.CommandOptions).
-				AddArgs("--full-index", rev)
+				AddArgs("--full-index", "--end-of-options", rev)
 		} else {
 			c, err := commit.Parent(0)
 			if err != nil {
@@ -122,13 +122,13 @@ func (r *Repository) RawDiff(rev string, diffType RawDiffFormat, w io.Writer, op
 			}
 			cmd = cmd.AddArgs("diff").
 				AddOptions(opt.CommandOptions).
-				AddArgs("--full-index", "-M", c.ID.String(), rev)
+				AddArgs("--full-index", "-M", c.ID.String(), "--end-of-options", rev)
 		}
 	case RawDiffPatch:
 		if commit.ParentsCount() == 0 {
 			cmd = cmd.AddArgs("format-patch").
 				AddOptions(opt.CommandOptions).
-				AddArgs("--full-index", "--no-signoff", "--no-signature", "--stdout", "--root", rev)
+				AddArgs("--full-index", "--no-signoff", "--no-signature", "--stdout", "--root", "--end-of-options", rev)
 		} else {
 			c, err := commit.Parent(0)
 			if err != nil {
@@ -136,7 +136,7 @@ func (r *Repository) RawDiff(rev string, diffType RawDiffFormat, w io.Writer, op
 			}
 			cmd = cmd.AddArgs("format-patch").
 				AddOptions(opt.CommandOptions).
-				AddArgs("--full-index", "--no-signoff", "--no-signature", "--stdout", rev+"..."+c.ID.String())
+				AddArgs("--full-index", "--no-signoff", "--no-signature", "--stdout", "--end-of-options", rev+"..."+c.ID.String())
 		}
 	default:
 		return fmt.Errorf("invalid diffType: %s", diffType)

--- a/repo_grep.go
+++ b/repo_grep.go
@@ -96,6 +96,7 @@ func (r *Repository) Grep(pattern string, opts ...GrepOptions) []*GrepResult {
 	if opt.ExtendedRegexp {
 		cmd.AddArgs("--extended-regexp")
 	}
+	cmd.AddArgs("--end-of-options")
 	cmd.AddArgs(pattern, opt.Tree)
 	if opt.Pathspec != "" {
 		cmd.AddArgs("--", opt.Pathspec)

--- a/repo_pull.go
+++ b/repo_pull.go
@@ -32,6 +32,7 @@ func MergeBase(repoPath, base, head string, opts ...MergeBaseOptions) (string, e
 
 	stdout, err := NewCommand("merge-base").
 		AddOptions(opt.CommandOptions).
+		AddArgs("--end-of-options").
 		AddArgs(base, head).
 		RunInDirWithTimeout(opt.Timeout, repoPath)
 	if err != nil {

--- a/repo_reference.go
+++ b/repo_reference.go
@@ -56,7 +56,7 @@ func ShowRefVerify(repoPath, ref string, opts ...ShowRefVerifyOptions) (string, 
 		opt = opts[0]
 	}
 
-	cmd := NewCommand("show-ref", "--verify", ref).AddOptions(opt.CommandOptions)
+	cmd := NewCommand("show-ref", "--verify", "--end-of-options", ref).AddOptions(opt.CommandOptions)
 	stdout, err := cmd.RunInDirWithTimeout(opt.Timeout, repoPath)
 	if err != nil {
 		if strings.Contains(err.Error(), "not a valid ref") {
@@ -162,6 +162,7 @@ func SymbolicRef(repoPath string, opts ...SymbolicRefOptions) (string, error) {
 	if opt.Name == "" {
 		opt.Name = "HEAD"
 	}
+	cmd.AddArgs("--end-of-options")
 	cmd.AddArgs(opt.Name)
 	if opt.Ref != "" {
 		cmd.AddArgs(opt.Ref)
@@ -281,6 +282,7 @@ func DeleteBranch(repoPath, name string, opts ...DeleteBranchOptions) error {
 	} else {
 		cmd.AddArgs("-d")
 	}
+	cmd.AddArgs("--end-of-options")
 	_, err := cmd.AddArgs(name).RunInDirWithTimeout(opt.Timeout, repoPath)
 	return err
 }

--- a/repo_remote.go
+++ b/repo_remote.go
@@ -49,6 +49,7 @@ func LsRemote(url string, opts ...LsRemoteOptions) ([]*Reference, error) {
 	if opt.Refs {
 		cmd.AddArgs("--refs")
 	}
+	cmd.AddArgs("--end-of-options")
 	cmd.AddArgs(url)
 	if len(opt.Patterns) > 0 {
 		cmd.AddArgs(opt.Patterns...)
@@ -120,6 +121,7 @@ func RemoteAdd(repoPath, name, url string, opts ...RemoteAddOptions) error {
 	if opt.MirrorFetch {
 		cmd.AddArgs("--mirror=fetch")
 	}
+	cmd.AddArgs("--end-of-options")
 
 	_, err := cmd.AddArgs(name, url).RunInDirWithTimeout(opt.Timeout, repoPath)
 	return err
@@ -166,7 +168,7 @@ func RemoteRemove(repoPath, name string, opts ...RemoteRemoveOptions) error {
 
 	_, err := NewCommand("remote", "remove").
 		AddOptions(opt.CommandOptions).
-		AddArgs(name).
+		AddArgs("--end-of-options", name).
 		RunInDirWithTimeout(opt.Timeout, repoPath)
 	if err != nil {
 		// the error status may differ from git clients
@@ -262,6 +264,7 @@ func RemoteGetURL(repoPath, name string, opts ...RemoteGetURLOptions) ([]string,
 	if opt.All {
 		cmd.AddArgs("--all")
 	}
+	cmd.AddArgs("--end-of-options")
 
 	stdout, err := cmd.AddArgs(name).RunInDirWithTimeout(opt.Timeout, repoPath)
 	if err != nil {
@@ -306,6 +309,7 @@ func RemoteSetURL(repoPath, name, newurl string, opts ...RemoteSetURLOptions) er
 		cmd.AddArgs("--push")
 	}
 
+	cmd.AddArgs("--end-of-options")
 	cmd.AddArgs(name, newurl)
 
 	if opt.Regex != "" {
@@ -361,6 +365,7 @@ func RemoteSetURLAdd(repoPath, name, newurl string, opts ...RemoteSetURLAddOptio
 		cmd.AddArgs("--push")
 	}
 
+	cmd.AddArgs("--end-of-options")
 	cmd.AddArgs(name, newurl)
 
 	_, err := cmd.RunInDirWithTimeout(opt.Timeout, repoPath)
@@ -407,6 +412,7 @@ func RemoteSetURLDelete(repoPath, name, regex string, opts ...RemoteSetURLDelete
 		cmd.AddArgs("--push")
 	}
 
+	cmd.AddArgs("--end-of-options")
 	cmd.AddArgs(name, regex)
 
 	_, err := cmd.RunInDirWithTimeout(opt.Timeout, repoPath)

--- a/repo_tag.go
+++ b/repo_tag.go
@@ -247,6 +247,7 @@ func (r *Repository) CreateTag(name, rev string, opts ...CreateTagOptions) error
 		if opt.Author != nil {
 			cmd.AddCommitter(opt.Author)
 		}
+		cmd.AddArgs("--end-of-options")
 	} else {
 		// 🚨 SECURITY: Prevent including unintended options in the path to the Git command.
 		cmd.AddArgs("--end-of-options")
@@ -279,7 +280,7 @@ func (r *Repository) DeleteTag(name string, opts ...DeleteTagOptions) error {
 		opt = opts[0]
 	}
 
-	_, err := NewCommand("tag", "--delete", name).
+	_, err := NewCommand("tag", "--delete", "--end-of-options", name).
 		AddOptions(opt.CommandOptions).
 		RunInDirWithTimeout(opt.Timeout, r.path)
 	return err


### PR DESCRIPTION
### Describe the pull request

Hardening: adds `--end-of-options` in every command in which a user-provided argument could be interpreted as an option (e.g. `--output=somefile` in `CommitByRevision`/`Log`.

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [ ] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code.
